### PR TITLE
README: Update developers count

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 | Urllib3                       |  `3.55`  | >=40  | 5242 | 0 (No SSL), >=5 (SSL) | >=188      |
 | PyCurl                        |  `0.75`  | >=15  | 5932 | Curl, LibCurl         | >=50       |
 | PyCurl (no SSL)               |  `0.68`  | >=15  | 5932 | Curl, LibCurl         | >=50       |
-| Faster_than_requests (no SSL) |  `0.50`  | 1     | 75   | 0                     | 1          |
-| Faster_than_requests          |  `0.45`  | 1     | 75   | 0                     | 1          |
+| Faster_than_requests (no SSL) |  `0.50`  | 1     | 75   | 0                     | 3          |
+| Faster_than_requests          |  `0.45`  | 1     | 75   | 0                     | 3          |
 
 <details>
 


### PR DESCRIPTION
Per the same methodology as the rest of the projects.

Could be argued that it's technically 2 contributors at this moment, but then someone else will have to update it and it will be 3, then someone else will have to update it and it will be 4, ad infinitum.

I am hoping to nip this paradox in the bud by skipping ahead by one increment.