### PR TITLE
Add to the documentation pip install wheel

### DIFF
--- a/.github/workflows/add-stars.yml
+++ b/.github/workflows/add-stars.yml
@@ -12,7 +12,7 @@ jobs:
         echo -e ":star: [@${{github.actor}}](https://github.com/${{github.actor}} '`date --iso-8601`')\t" >> README.md
 
     - name: Commit changes
-      uses: elstudio/actions-js-build/commit@v4
+      uses: elstudio/actions-js-build/commit@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PUSH_BRANCH: 'master'

--- a/README.md
+++ b/README.md
@@ -1653,3 +1653,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@Zardex1337](https://github.com/Zardex1337 '2022-05-08')	
 :star: [@jocago](https://github.com/jocago '2022-05-09')	
 :star: [@gnimmel](https://github.com/gnimmel '2022-05-11')	
+:star: [@sting8k](https://github.com/sting8k '2022-05-13')	

--- a/README.md
+++ b/README.md
@@ -1650,3 +1650,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@matkuki](https://github.com/matkuki '2022-04-14')	
 :star: [@SmartManoj](https://github.com/SmartManoj '2022-04-16')	
 :star: [@SmartManoj](https://github.com/SmartManoj '2022-04-21')	
+:star: [@Zardex1337](https://github.com/Zardex1337 '2022-05-08')	

--- a/README.md
+++ b/README.md
@@ -1659,3 +1659,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@Bing-su](https://github.com/Bing-su '2022-05-16')	
 :star: [@AdrianCert](https://github.com/AdrianCert '2022-05-18')	
 :star: [@asanoop24](https://github.com/asanoop24 '2022-05-18')	
+:star: [@zaphodfortytwo](https://github.com/zaphodfortytwo '2022-05-19')	

--- a/README.md
+++ b/README.md
@@ -1684,3 +1684,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@atlassion](https://github.com/atlassion '2022-07-04')	
 :star: [@cytsai1008](https://github.com/cytsai1008 '2022-07-05')	
 :star: [@bsouthern](https://github.com/bsouthern '2022-07-07')	
+:star: [@techrattt](https://github.com/techrattt '2022-07-09')	

--- a/README.md
+++ b/README.md
@@ -1652,3 +1652,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@SmartManoj](https://github.com/SmartManoj '2022-04-21')	
 :star: [@Zardex1337](https://github.com/Zardex1337 '2022-05-08')	
 :star: [@jocago](https://github.com/jocago '2022-05-09')	
+:star: [@gnimmel](https://github.com/gnimmel '2022-05-11')	

--- a/README.md
+++ b/README.md
@@ -1677,3 +1677,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@sk37025](https://github.com/sk37025 '2022-06-15')	
 :star: [@Alexb309](https://github.com/Alexb309 '2022-06-16')	
 :star: [@alimp5](https://github.com/alimp5 '2022-06-17')	
+:star: [@oldhroft](https://github.com/oldhroft '2022-06-25')	

--- a/README.md
+++ b/README.md
@@ -1687,3 +1687,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@techrattt](https://github.com/techrattt '2022-07-09')	
 :star: [@vnicetn](https://github.com/vnicetn '2022-07-11')	
 :star: [@Perry-xD](https://github.com/Perry-xD '2022-07-12')	
+:star: [@israelvf](https://github.com/israelvf '2022-07-13')	

--- a/README.md
+++ b/README.md
@@ -1660,3 +1660,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@AdrianCert](https://github.com/AdrianCert '2022-05-18')	
 :star: [@asanoop24](https://github.com/asanoop24 '2022-05-18')	
 :star: [@zaphodfortytwo](https://github.com/zaphodfortytwo '2022-05-19')	
+:star: [@Ozerioss](https://github.com/Ozerioss '2022-05-20')	

--- a/README.md
+++ b/README.md
@@ -1409,7 +1409,7 @@ For info about how to install [Docker for Windows.](https://docs.docker.com/dock
 
 ```
 nimble install nimpy
-nim c -d:ssl -d:danger --app:lib --out:faster_than_requests.pyd faster_than_requests.nim
+nim c -d:ssl -d:danger --app:lib --tlsEmulation:on --out:faster_than_requests.pyd faster_than_requests.nim
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1673,3 +1673,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@breezechen](https://github.com/breezechen '2022-06-02')	
 :star: [@TobeTek](https://github.com/TobeTek '2022-06-07')	
 :star: [@antonpetrov145](https://github.com/antonpetrov145 '2022-06-09')	
+:star: [@MartianDominic](https://github.com/MartianDominic '2022-06-14')	

--- a/README.md
+++ b/README.md
@@ -1669,3 +1669,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@Arthavruksha](https://github.com/Arthavruksha '2022-05-31')	
 :star: [@xdroff](https://github.com/xdroff '2022-05-31')	
 :star: [@ShodhArthavruksha](https://github.com/ShodhArthavruksha '2022-06-01')	
+:star: [@aziddddd](https://github.com/aziddddd '2022-06-01')	

--- a/README.md
+++ b/README.md
@@ -1668,3 +1668,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@rapjul](https://github.com/rapjul '2022-05-27')	
 :star: [@Arthavruksha](https://github.com/Arthavruksha '2022-05-31')	
 :star: [@xdroff](https://github.com/xdroff '2022-05-31')	
+:star: [@ShodhArthavruksha](https://github.com/ShodhArthavruksha '2022-06-01')	

--- a/README.md
+++ b/README.md
@@ -1654,3 +1654,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@jocago](https://github.com/jocago '2022-05-09')	
 :star: [@gnimmel](https://github.com/gnimmel '2022-05-11')	
 :star: [@sting8k](https://github.com/sting8k '2022-05-13')	
+:star: [@c4p-n1ck](https://github.com/c4p-n1ck '2022-05-13')	

--- a/README.md
+++ b/README.md
@@ -1657,3 +1657,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@c4p-n1ck](https://github.com/c4p-n1ck '2022-05-13')	
 :star: [@w0xi](https://github.com/w0xi '2022-05-15')	
 :star: [@Bing-su](https://github.com/Bing-su '2022-05-16')	
+:star: [@AdrianCert](https://github.com/AdrianCert '2022-05-18')	

--- a/README.md
+++ b/README.md
@@ -1682,3 +1682,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@rainmana](https://github.com/rainmana '2022-06-25')	
 :star: [@amitdo](https://github.com/amitdo '2022-07-03')	
 :star: [@atlassion](https://github.com/atlassion '2022-07-04')	
+:star: [@cytsai1008](https://github.com/cytsai1008 '2022-07-05')	

--- a/README.md
+++ b/README.md
@@ -1655,3 +1655,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@gnimmel](https://github.com/gnimmel '2022-05-11')	
 :star: [@sting8k](https://github.com/sting8k '2022-05-13')	
 :star: [@c4p-n1ck](https://github.com/c4p-n1ck '2022-05-13')	
+:star: [@w0xi](https://github.com/w0xi '2022-05-15')	

--- a/README.md
+++ b/README.md
@@ -1676,3 +1676,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@MartianDominic](https://github.com/MartianDominic '2022-06-14')	
 :star: [@sk37025](https://github.com/sk37025 '2022-06-15')	
 :star: [@Alexb309](https://github.com/Alexb309 '2022-06-16')	
+:star: [@alimp5](https://github.com/alimp5 '2022-06-17')	

--- a/README.md
+++ b/README.md
@@ -1671,3 +1671,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@ShodhArthavruksha](https://github.com/ShodhArthavruksha '2022-06-01')	
 :star: [@aziddddd](https://github.com/aziddddd '2022-06-01')	
 :star: [@breezechen](https://github.com/breezechen '2022-06-02')	
+:star: [@TobeTek](https://github.com/TobeTek '2022-06-07')	

--- a/README.md
+++ b/README.md
@@ -1680,3 +1680,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@oldhroft](https://github.com/oldhroft '2022-06-25')	
 :star: [@davidcralph](https://github.com/davidcralph '2022-06-25')	
 :star: [@rainmana](https://github.com/rainmana '2022-06-25')	
+:star: [@amitdo](https://github.com/amitdo '2022-07-03')	

--- a/README.md
+++ b/README.md
@@ -1686,3 +1686,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@bsouthern](https://github.com/bsouthern '2022-07-07')	
 :star: [@techrattt](https://github.com/techrattt '2022-07-09')	
 :star: [@vnicetn](https://github.com/vnicetn '2022-07-11')	
+:star: [@Perry-xD](https://github.com/Perry-xD '2022-07-12')	

--- a/README.md
+++ b/README.md
@@ -1656,3 +1656,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@sting8k](https://github.com/sting8k '2022-05-13')	
 :star: [@c4p-n1ck](https://github.com/c4p-n1ck '2022-05-13')	
 :star: [@w0xi](https://github.com/w0xi '2022-05-15')	
+:star: [@Bing-su](https://github.com/Bing-su '2022-05-16')	

--- a/README.md
+++ b/README.md
@@ -1662,3 +1662,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@zaphodfortytwo](https://github.com/zaphodfortytwo '2022-05-19')	
 :star: [@Ozerioss](https://github.com/Ozerioss '2022-05-20')	
 :star: [@nkot56297](https://github.com/nkot56297 '2022-05-21')	
+:star: [@sendyputra](https://github.com/sendyputra '2022-05-22')	

--- a/README.md
+++ b/README.md
@@ -1663,3 +1663,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@Ozerioss](https://github.com/Ozerioss '2022-05-20')	
 :star: [@nkot56297](https://github.com/nkot56297 '2022-05-21')	
 :star: [@sendyputra](https://github.com/sendyputra '2022-05-22')	
+:star: [@thedrow](https://github.com/thedrow '2022-05-23')	

--- a/README.md
+++ b/README.md
@@ -1665,3 +1665,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@sendyputra](https://github.com/sendyputra '2022-05-22')	
 :star: [@thedrow](https://github.com/thedrow '2022-05-23')	
 :star: [@MinhHuyDev](https://github.com/MinhHuyDev '2022-05-24')	
+:star: [@rapjul](https://github.com/rapjul '2022-05-27')	

--- a/README.md
+++ b/README.md
@@ -1661,3 +1661,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@asanoop24](https://github.com/asanoop24 '2022-05-18')	
 :star: [@zaphodfortytwo](https://github.com/zaphodfortytwo '2022-05-19')	
 :star: [@Ozerioss](https://github.com/Ozerioss '2022-05-20')	
+:star: [@nkot56297](https://github.com/nkot56297 '2022-05-21')	

--- a/README.md
+++ b/README.md
@@ -1670,3 +1670,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@xdroff](https://github.com/xdroff '2022-05-31')	
 :star: [@ShodhArthavruksha](https://github.com/ShodhArthavruksha '2022-06-01')	
 :star: [@aziddddd](https://github.com/aziddddd '2022-06-01')	
+:star: [@breezechen](https://github.com/breezechen '2022-06-02')	

--- a/README.md
+++ b/README.md
@@ -1674,3 +1674,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@TobeTek](https://github.com/TobeTek '2022-06-07')	
 :star: [@antonpetrov145](https://github.com/antonpetrov145 '2022-06-09')	
 :star: [@MartianDominic](https://github.com/MartianDominic '2022-06-14')	
+:star: [@sk37025](https://github.com/sk37025 '2022-06-15')	

--- a/README.md
+++ b/README.md
@@ -1678,3 +1678,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@Alexb309](https://github.com/Alexb309 '2022-06-16')	
 :star: [@alimp5](https://github.com/alimp5 '2022-06-17')	
 :star: [@oldhroft](https://github.com/oldhroft '2022-06-25')	
+:star: [@davidcralph](https://github.com/davidcralph '2022-06-25')	

--- a/README.md
+++ b/README.md
@@ -1651,3 +1651,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@SmartManoj](https://github.com/SmartManoj '2022-04-16')	
 :star: [@SmartManoj](https://github.com/SmartManoj '2022-04-21')	
 :star: [@Zardex1337](https://github.com/Zardex1337 '2022-05-08')	
+:star: [@jocago](https://github.com/jocago '2022-05-09')	

--- a/README.md
+++ b/README.md
@@ -1658,3 +1658,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@w0xi](https://github.com/w0xi '2022-05-15')	
 :star: [@Bing-su](https://github.com/Bing-su '2022-05-16')	
 :star: [@AdrianCert](https://github.com/AdrianCert '2022-05-18')	
+:star: [@asanoop24](https://github.com/asanoop24 '2022-05-18')	

--- a/README.md
+++ b/README.md
@@ -1683,3 +1683,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@amitdo](https://github.com/amitdo '2022-07-03')	
 :star: [@atlassion](https://github.com/atlassion '2022-07-04')	
 :star: [@cytsai1008](https://github.com/cytsai1008 '2022-07-05')	
+:star: [@bsouthern](https://github.com/bsouthern '2022-07-07')	

--- a/README.md
+++ b/README.md
@@ -1681,3 +1681,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@davidcralph](https://github.com/davidcralph '2022-06-25')	
 :star: [@rainmana](https://github.com/rainmana '2022-06-25')	
 :star: [@amitdo](https://github.com/amitdo '2022-07-03')	
+:star: [@atlassion](https://github.com/atlassion '2022-07-04')	

--- a/README.md
+++ b/README.md
@@ -1664,3 +1664,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@nkot56297](https://github.com/nkot56297 '2022-05-21')	
 :star: [@sendyputra](https://github.com/sendyputra '2022-05-22')	
 :star: [@thedrow](https://github.com/thedrow '2022-05-23')	
+:star: [@MinhHuyDev](https://github.com/MinhHuyDev '2022-05-24')	

--- a/README.md
+++ b/README.md
@@ -1667,3 +1667,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@MinhHuyDev](https://github.com/MinhHuyDev '2022-05-24')	
 :star: [@rapjul](https://github.com/rapjul '2022-05-27')	
 :star: [@Arthavruksha](https://github.com/Arthavruksha '2022-05-31')	
+:star: [@xdroff](https://github.com/xdroff '2022-05-31')	

--- a/README.md
+++ b/README.md
@@ -1675,3 +1675,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@antonpetrov145](https://github.com/antonpetrov145 '2022-06-09')	
 :star: [@MartianDominic](https://github.com/MartianDominic '2022-06-14')	
 :star: [@sk37025](https://github.com/sk37025 '2022-06-15')	
+:star: [@Alexb309](https://github.com/Alexb309 '2022-06-16')	

--- a/README.md
+++ b/README.md
@@ -1666,3 +1666,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@thedrow](https://github.com/thedrow '2022-05-23')	
 :star: [@MinhHuyDev](https://github.com/MinhHuyDev '2022-05-24')	
 :star: [@rapjul](https://github.com/rapjul '2022-05-27')	
+:star: [@Arthavruksha](https://github.com/Arthavruksha '2022-05-31')	

--- a/README.md
+++ b/README.md
@@ -1672,3 +1672,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@aziddddd](https://github.com/aziddddd '2022-06-01')	
 :star: [@breezechen](https://github.com/breezechen '2022-06-02')	
 :star: [@TobeTek](https://github.com/TobeTek '2022-06-07')	
+:star: [@antonpetrov145](https://github.com/antonpetrov145 '2022-06-09')	

--- a/README.md
+++ b/README.md
@@ -1688,3 +1688,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@vnicetn](https://github.com/vnicetn '2022-07-11')	
 :star: [@Perry-xD](https://github.com/Perry-xD '2022-07-12')	
 :star: [@israelvf](https://github.com/israelvf '2022-07-13')	
+:star: [@BernardoOlisan](https://github.com/BernardoOlisan '2022-07-14')	

--- a/README.md
+++ b/README.md
@@ -1685,3 +1685,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@cytsai1008](https://github.com/cytsai1008 '2022-07-05')	
 :star: [@bsouthern](https://github.com/bsouthern '2022-07-07')	
 :star: [@techrattt](https://github.com/techrattt '2022-07-09')	
+:star: [@vnicetn](https://github.com/vnicetn '2022-07-11')	

--- a/README.md
+++ b/README.md
@@ -1679,3 +1679,4 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@alimp5](https://github.com/alimp5 '2022-06-17')	
 :star: [@oldhroft](https://github.com/oldhroft '2022-06-25')	
 :star: [@davidcralph](https://github.com/davidcralph '2022-06-25')	
+:star: [@rainmana](https://github.com/rainmana '2022-06-25')	


### PR DESCRIPTION
So I saw a issue that is open, this issue is saying that installation with `pip install faster_than_requests` fails, is because you need to install this first, in order to be able to install the wheel package, It would be a good idea to add in the docs, install first `pip install wheel` 

:)
