### PR TITLE
Add wheel to the installation requirement

### DIFF
--- a/dist/faster_than_requests/setup.cfg
+++ b/dist/faster_than_requests/setup.cfg
@@ -2,7 +2,7 @@
 [options]
 zip_safe = True
 python_requires  = >=3.8
-install_requires = nimporter
+install_requires = nimporter wheel
 setup_requires   = choosenim_install
 packages         = faster_than_requests
 


### PR DESCRIPTION
If you do not have `wheel` installed the library installation fails.

Closes #189

I cant really test this, since there is no setup.py in the root of the repo, so commands like: ` pip3 install git+https://github.com/Letme/faster-than-requests.git@patch-1` fail, but it would be cool to support them. Also I would never commit the artifacts (in here they are in dists folder) since they are created by build (and now you invented script to delete them and stuff). Anyway all that is part of the architecture decision, so if you want me to improve that I can probably dig into it, but until then I let you test this fix - which should install `wheel` before installing the library (otherwise it does not work).