### PR TITLE
Revert the star commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1692,4 +1692,3 @@ Projects that use Cython wont count the whole Cython on the LoC, so we wont neit
 :star: [@ZenoMilk12](https://github.com/ZenoMilk12 '2022-07-19')	
 :star: [@rundef](https://github.com/rundef '2022-07-20')	
 :star: [@semihyesilyurt](https://github.com/semihyesilyurt '2022-07-20')	
-:star: [@Letme](https://github.com/Letme '2022-07-21')	


### PR DESCRIPTION
I never wanted a contribution to the library when I starred the repository. I wanted fast access so that I might contribute in case there will be something to contribute.